### PR TITLE
集計ページのレイアウトを最新化する

### DIFF
--- a/vue/src/components/CoArea.vue
+++ b/vue/src/components/CoArea.vue
@@ -2,7 +2,10 @@
   <section class="co-area">
     <!-- 自分 -->
     <div class="player-wrapper">
-      <article class="player">
+      <article
+        class="player"
+        :class="{ selected: isSelected(player.playerName) }"
+      >
         <figure class="player-icon">
           <img :src="RoleList[player.playerRole.roleName]" alt="" />
         </figure>
@@ -17,7 +20,12 @@
       </article>
 
       <!-- 自分以外のプレイヤー -->
-      <article class="player" v-for="(val, key) in otherPlayerList" :key="key">
+      <article
+        class="player"
+        :class="{ selected: isSelected(val.name) }"
+        v-for="(val, key) in otherPlayerList"
+        :key="key"
+      >
         <figure class="player-icon">
           <img :src="RoleList[val.role.roleName]" :alt="val.role.roleName" />
         </figure>
@@ -33,7 +41,7 @@
 <script>
 export default {
   name: "CoArea",
-  props: ["otherPlayerList", "player", "coRole"],
+  props: ["otherPlayerList", "player", "coRole", "selectedPlayers"],
   data() {
     return {
       RoleList: {
@@ -55,6 +63,25 @@ export default {
         吊り人: require("../assets/images/fukidashi/tsuribito.png"),
       },
     };
+  },
+  methods: {
+    isSelected: function (name) {
+      // 投票ページ以外ではselectedPlayersは存在しないのでfalseを返す
+      if (!this.selectedPlayers) {
+        return false;
+      }
+
+      let selectedPlayersName = [];
+      this.selectedPlayers.forEach((player) => {
+        selectedPlayersName.push(player.name);
+      });
+
+      if (selectedPlayersName.includes(name)) {
+        return true;
+      } else {
+        return false;
+      }
+    },
   },
 };
 </script>
@@ -108,6 +135,44 @@ export default {
 
       .me {
         text-decoration: underline;
+      }
+    }
+
+    .player.selected {
+      .player-icon {
+        position: relative;
+
+        img {
+          filter: grayscale(100%);
+        }
+
+        &::after {
+          position: absolute;
+          left: 0;
+          width: calc(100% * 1.414);
+          height: 2px;
+          content: "";
+          background-color: red;
+          transform: rotateZ(45deg);
+          transform-origin: left top;
+        }
+
+        &::before {
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          z-index: 1;
+          width: calc(100% * 1.414);
+          height: 2px;
+          content: "";
+          background-color: red;
+          transform: rotateZ(-45deg);
+          transform-origin: left top;
+        }
+      }
+
+      .co-icon__img {
+        filter: grayscale(100%);
       }
     }
   }

--- a/vue/src/views/TallyTermPage.vue
+++ b/vue/src/views/TallyTermPage.vue
@@ -2,40 +2,47 @@
   <main class="tally_page">
     <section class="vote_result">
       <h2>
-        選ばれたのは,<br class="sp" />
+        選ばれたのは,<br />
         <span
           v-for="player in tallyResult.selectedPlayers"
           v-bind:key="player.id"
         >
-          {{ player.name }}<br class="sp" />
+          {{ player.name }}<br />
         </span>
         です．
       </h2>
     </section>
 
-    <RoleCardDisplay
-      :playerRole="playerRole"
-      :playerName="playerName"
+    <coArea
       :otherPlayerList="otherPlayerList"
+      :player="{ playerName: playerName, playerRole: playerRole }"
+      :coRole="this.coRole"
+      :selectedPlayers="this.tallyResult.selectedPlayers"
     />
 
-    <section class="vote_detail">
-      <h2>投票数</h2>
-      <div class="table">
-        <dl v-for="player in tallyResult.players" v-bind:key="player.id">
-          <dt>
-            {{ player.name }}
-          </dt>
-          <dd>
-            {{ player.voteCount }}
-          </dd>
-        </dl>
-      </div>
-    </section>
+    <div class="col2">
+      <section class="display-rolls">
+        <DisplayRolls />
+      </section>
+      <section class="vote_detail">
+        <h2>得票数</h2>
+        <ul>
+          <li v-for="player in tallyResult.players" v-bind:key="player.id">
+            <span>{{ player.name }}</span>
+            <span>：</span>
+            <span>{{ player.voteCount }} </span>
+          </li>
+        </ul>
 
-    <myButton class="btn" :method="gotoResult" :text="'結果ページに移動する'" />
+        <myButton
+          class="btn"
+          :method="gotoResult"
+          :text="'結果ページに移動する'"
+        />
+      </section>
+    </div>
 
-    <modal :width="'90%'" :height="'auto'"  name="done-tally-modal">
+    <modal :width="'90%'" :height="'auto'" name="done-tally-modal">
       <div class="modal-header">
         <h3>全員投票が完了しました．<br />集計結果を表示します．</h3>
         <myButton class="tally-modal-btn" :method="closeModal" :text="'OK'" />
@@ -49,9 +56,11 @@ import axios from "axios";
 import SockJS from "sockjs-client";
 import Stomp from "webstomp-client";
 
-import RoleCardDisplay from "@/components/RoleCardDisplay";
 import myButton from "@/components/Button";
-import { JINROH_API_BASE_URL} from "../Env";
+import coArea from "@/components/CoArea.vue";
+import DisplayRolls from "@/components/DisplayRolls.vue";
+
+import { JINROH_API_BASE_URL } from "../Env";
 
 export default {
   name: "TallyTermPage",
@@ -88,7 +97,17 @@ export default {
       },
     };
   },
-  components: { RoleCardDisplay, myButton },
+  components: { myButton, coArea, DisplayRolls },
+  computed: {
+    coRole: {
+      get() {
+        return this.$store.state.coRole;
+      },
+      set(coRole) {
+        this.$store.commit("setCoRole", coRole);
+      },
+    },
+  },
   mounted() {
     axios
       .get(JINROH_API_BASE_URL + "/tally-index", { withCredentials: true })
@@ -121,6 +140,7 @@ export default {
         });
       });
     },
+    addClassToSelectedPlayer: function () {},
     gotoResult: function () {
       axios
         .get(JINROH_API_BASE_URL + "/show-result", { withCredentials: true })
@@ -136,78 +156,96 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.vote_result {
+  span {
+    color: red;
+  }
+}
+
 h2 {
-  text-align: center;
   font-weight: normal;
+  text-align: center;
+
   span {
     font-size: 1.05em;
     font-weight: bold;
   }
 }
 
+.col2 {
+  display: flex;
+  column-gap: 32px;
+
+  .display-rolls {
+    width: 100%;
+    max-width: 335px;
+    margin: 0;
+  }
+}
+
 .btn {
-  text-align: center;
   display: block;
   width: 16rem;
-  margin: 0 auto;
+  margin: 16px auto;
+  text-align: center;
 }
 
 .vote_detail {
+  width: 100%;
+  padding: 1em;
+  margin: 0;
   text-align: center;
+  background-color: #eee;
+
   h2 {
-    display: inline-block;
-    padding: 0 0.5em;
-    font-size: 1.5em;
-    border-bottom: 2px red solid;
+    font-weight: bold;
+    text-align: center;
   }
-  .table {
+
+  ul {
     display: flex;
-    justify-content: center;
-    dl {
-      display: flex;
-      flex-direction: column;
-      min-width: 20%;
-      dt {
-        padding: 0.5em;
-      }
-      dd {
-        padding: 0.5em;
-      }
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem 0;
+
+    li {
+      display: grid;
+      grid-template-columns: 10rem 1rem 1rem;
+      justify-content: center;
+      width: 100%;
+      text-align: left;
+      list-style: none;
     }
   }
 }
 
 .modal-header {
   display: flex;
-  justify-content: center;
   flex-direction: column;
-
-  height: 100%;
+  justify-content: center;
   width: 100%;
+  height: 100%;
   text-align: center;
 
   h3 {
     margin-top: 2rem;
   }
+
   .tally-modal-btn {
     width: 10rem;
-    margin: 2rem auto;
     padding: 0.5em 0;
+    margin: 2rem auto;
   }
 }
 
 @media screen and (max-width: 639px) {
-  .vote_detail {
-    .table {
-      flex-direction: column;
+  .col2 {
+    flex-direction: column-reverse;
+    flex-wrap: wrap;
+    row-gap: 32px;
 
-      dl {
-        flex-direction: row;
-        justify-content: center;
-        dt {
-          min-width: 10rem;
-        }
-      }
+    .display-rolls {
+      max-width: 100%;
     }
   }
 }


### PR DESCRIPTION
■集計ページのレイアウトを最新化した
■処刑されたプレイヤーを可視化した
・SP版
![スクリーンショット 2021-10-09 14 42 38](https://user-images.githubusercontent.com/9443634/136645693-630bf3ce-51f9-47c1-a516-27d9482ebf20.png)
・PC版
![スクリーンショット 2021-10-09 14 41 50](https://user-images.githubusercontent.com/9443634/136645695-d8b642ef-0a39-4412-a54b-dd7ec8a596cc.png)

