### PR TITLE
vue-config.jsで開発環境でのホストをlocalhostに固定した

### DIFF
--- a/vue/vue.config.js
+++ b/vue/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    devServer: {
+        host: 'localhost',
+    }
+}


### PR DESCRIPTION
ホットリロード時の処理でsockjsが使われており，その際に発生するエラーだと思う．．

https://uyamazak.hatenablog.com/entry/2018/07/31/115457#:~:text=%E3%81%A7%E3%81%84%E3%81%84%E3%81%8B%E3%81%AA%E3%80%82-,%E7%B7%A8%E9%9B%86%E5%BE%8C%E3%81%AE%E3%82%AA%E3%83%BC%E3%83%88%E3%83%AA%E3%83%AD%E3%83%BC%E3%83%89%E3%81%8C%E5%8B%95%E3%81%8B%E3%81%AA%E3%81%84,-%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%81%A7%E9%96%8B

