### PR TITLE
夜の行動のUIを改善した

### DIFF
--- a/vue/src/components/Button.vue
+++ b/vue/src/components/Button.vue
@@ -34,4 +34,11 @@ a {
     transition: 0.1s;
   }
 }
+
+a.disabled {
+    color: gray;
+    border: 1px solid gray;
+    pointer-events: none;
+  
+}
 </style>

--- a/vue/src/components/NightAction/NightKaitoAction.vue
+++ b/vue/src/components/NightAction/NightKaitoAction.vue
@@ -8,13 +8,13 @@
             type="radio"
             v-model="checkedPlayerID"
             :value="otherPlayer.id"
-            :disabled="is_votable"
+            :disabled="isDisabled"
           />
           {{ otherPlayer.name }}
         </label>
       </li>
     </ul>
-    <myButton :text="'選んだ相手と入れ替える'" :method="kaito" />
+    <myButton :text="'選んだ相手と入れ替える'" :method="kaito" :class="{'disabled': isDisabled}" />
 
     <div v-if="kaitoResult.actLog">
         <!-- FIXME: ここ手抜きしました．．フロント側で加工し表示するべき -->
@@ -36,7 +36,8 @@ export default {
       checkedPlayerID: 0,
       kaitoResult: {
           actLog: null
-      }
+      },
+      isDisabled: false,
     };
   },
   props: {
@@ -60,6 +61,7 @@ export default {
         )
         .then((response) => {
           this.kaitoResult = response.data;
+          this.isDisabled = true;
           console.log(response.data);
         })
         .catch(() => {});

--- a/vue/src/components/NightAction/NightKaitoAction.vue
+++ b/vue/src/components/NightAction/NightKaitoAction.vue
@@ -15,6 +15,7 @@
       </li>
     </ul>
     <myButton :text="'選んだ相手と入れ替える'" :method="kaito" :class="{'disabled': isDisabled}" />
+    <p style="color:red" v-if="errorMessage">{{ errorMessage }}</p>
 
     <div v-if="kaitoResult.actLog">
         <!-- FIXME: ここ手抜きしました．．フロント側で加工し表示するべき -->
@@ -33,11 +34,12 @@ export default {
   components: { myButton },
   data() {
     return {
-      checkedPlayerID: 0,
+      checkedPlayerID: null,
       kaitoResult: {
           actLog: null
       },
       isDisabled: false,
+      errorMessage: "",
     };
   },
   props: {
@@ -48,6 +50,11 @@ export default {
   },
   methods: {
     kaito: function () {
+      
+      this.errorMessage = this.checkedPlayerID
+      ? "" : "プレイヤーが選ばれていません";
+      if(this.errorMessage) return;
+
       axios
         .post(
             JINROH_API_BASE_URL + "/night/kaito",

--- a/vue/src/components/NightAction/NightUranaiAction.vue
+++ b/vue/src/components/NightAction/NightUranaiAction.vue
@@ -8,7 +8,7 @@
             type="radio"
             v-model="selectedUranai"
             v-bind:value="'PLAYER:' + player.id"
-            :disabled="isSelected"
+            :disabled="isDisabled"
           />
           {{ player.name }}
         </label>
@@ -19,14 +19,14 @@
             type="radio"
             v-model="selectedUranai"
             value="HOLIDAY_ROLES"
-            :disabled="isSelected"
+            :disabled="isDisabled"
           />
           お休み中のロール
         </label>
       </li>
     </ul>
 
-    <myButton class="btn" :method="uranai" :text="'占う'" />
+    <myButton class="btn" :method="uranai" :text="'占う'" :class="{'disabled':isDisabled}" />
 
     <p>占い結果</p>
     <div v-if="uranaiResult.status == 'PLAYER'">
@@ -75,6 +75,7 @@ export default {
           },
         ],
       },
+      isDisabled: false,
     };
   },
   props: {
@@ -109,6 +110,7 @@ export default {
         )
         .then((response) => {
           this.uranaiResult = response.data;
+          this.isDisabled = true;
           console.log(response.data);
         })
         .catch(() => {});


### PR DESCRIPTION
## 夜の行動UI修正
### 怪盗
- プレイヤーを選ばない状態で行動ボタンを押下するとエラーメッセージを表示
- 行動完了後はラジオボタンを非活性化
![kaito](https://user-images.githubusercontent.com/9443634/169636795-78d24eb0-02d3-42fd-9444-26b811a1cbb3.gif)

### 占い師
- 行動完了後はラジオボタンを非活性化
※プレイヤーを選ばない状態で行動ボタンを押下した場合、占い師は「行動しなかった」というレスポンスを受け取る
![uranaishi](https://user-images.githubusercontent.com/9443634/169636838-b1d34c13-a95f-4943-b286-74ba58a3f931.gif)

