### PR TITLE
人狼陣営の勝利（潜伏成功）が首つりになっている問題を修正した

### DIFF
--- a/vue/src/components/ResultImage.vue
+++ b/vue/src/components/ResultImage.vue
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-  name: "resultImage",
+  name: "ResultImage",
   props: ["judge"],
   mounted() {
     this.$emit("getJudgeText", this.judgeResults[this.judge].text);

--- a/vue/src/components/resultImage.vue
+++ b/vue/src/components/resultImage.vue
@@ -49,7 +49,7 @@ export default {
 
 <style lang="scss" scoped>
 .winner {
-  max-width: 20rem;
+  max-width: 21rem;
   margin: auto;
   text-align: center;
 
@@ -67,6 +67,10 @@ export default {
 @media screen and (max-width: 639px) {
   .winner {
     max-width: 15rem;
+    .winner-text{
+      font-size: 20px;
+      word-break: keep-all;
+    }
   }
 }
 </style>

--- a/vue/src/views/ResultTermPage.vue
+++ b/vue/src/views/ResultTermPage.vue
@@ -2,7 +2,7 @@
   <main class="result_page">
     <modal :width="'90%'" :height="'auto'" name="result-modal">
       <div class="result-modal">
-        <resultImage :judge="judge" @getJudgeText="judgeText = $event" />
+        <ResultImage :judge="judge" @getJudgeText="judgeText = $event" />
         <myButton class="btn" :method="closeModal" :text="'OK'" />
       </div>
     </modal>
@@ -51,7 +51,7 @@ import axios from "axios";
 import SockJS from "sockjs-client";
 import Stomp from "webstomp-client";
 
-import resultImage from "@/components/resultImage.vue";
+import ResultImage from "@/components/ResultImage.vue";
 import PlayerResult from "@/components/PlayerResult.vue";
 import myButton from "@/components/Button.vue";
 import { JINROH_API_BASE_URL } from "../Env";
@@ -87,7 +87,7 @@ export default {
       },
     };
   },
-  components: { resultImage, myButton, PlayerResult },
+  components: { ResultImage, myButton, PlayerResult },
   computed: {
     // playerListを勝者と敗者に振り分ける
     winPlayerList: function () {


### PR DESCRIPTION
人狼陣営の勝利（潜伏成功）が首つりになっている問題を修正した。
ついでにコンポーネント名の命名規則統一のために頭文字を小文字から大文字に修正した（resultImage->ResultImage）
## 修正前
### PC/SP共通
![image](https://user-images.githubusercontent.com/9443634/169637491-f16ecda2-639a-4840-9473-cb7d0c663854.png)

## 修正後
### PC
![image](https://user-images.githubusercontent.com/9443634/169637529-03c78029-ca6f-4404-a19f-fe7cff9d4c06.png)

### SP
![image](https://user-images.githubusercontent.com/9443634/169637539-ee615044-ab95-4482-80e2-62aeaf1c0d72.png)
