### PR TITLE
Draft: react-error-boundary を導入し、エラー表示コンポーネントを実装した

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -12,6 +12,7 @@
         "html-react-parser": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.11",
         "react-responsive-modal": "^6.4.2",
         "react-router-dom": "^6.14.1",
         "sockjs-client": "^1.6.1",
@@ -746,7 +747,6 @@
       "version": "7.22.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
       "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -11838,6 +11838,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+      "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -12059,8 +12070,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
@@ -15109,7 +15119,6 @@
       "version": "7.22.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
       "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -22835,6 +22844,14 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-error-boundary": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+      "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -22992,8 +23009,7 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",

--- a/react/package.json
+++ b/react/package.json
@@ -22,6 +22,7 @@
     "html-react-parser": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-responsive-modal": "^6.4.2",
     "react-router-dom": "^6.14.1",
     "sockjs-client": "^1.6.1",

--- a/react/src/components/Button/Button.tsx
+++ b/react/src/components/Button/Button.tsx
@@ -1,12 +1,15 @@
+import { cx } from 'styled-system/css';
 import type { RecipeVariantProps } from 'styled-system/types/recipe';
 import { button } from './button.css.ts';
 
 type Props = {
+  customStyle?: string;
   children: React.ReactNode;
 } & React.ButtonHTMLAttributes<HTMLButtonElement> &
   RecipeVariantProps<typeof button>;
 
 export const Button: React.FC<Props> = ({
+  customStyle,
   children,
   color,
   shape,
@@ -14,7 +17,10 @@ export const Button: React.FC<Props> = ({
   ...props
 }: Props) => {
   return (
-    <button className={button({ color, shape, size })} {...props}>
+    <button
+      className={cx(button({ color, shape, size }), customStyle ?? '')}
+      {...props}
+    >
       {children}
     </button>
   );

--- a/react/src/components/ErrorFallback/ErrorFallback.tsx
+++ b/react/src/components/ErrorFallback/ErrorFallback.tsx
@@ -1,0 +1,43 @@
+import type { FallbackProps } from 'react-error-boundary';
+import { css } from 'styled-system/css';
+import { ErrorMessage } from './ErrorMessage';
+import { Button } from '@/components';
+
+const styles = {
+  allert: css({
+    backgroundColor: '#FFF5F5',
+    margin: '2rem auto 0',
+    padding: '1rem',
+    borderRadius: '0.5rem',
+  }),
+  button: css({
+    margin: '1rem auto',
+  }),
+};
+
+type Props = {
+  error: Error;
+  resetErrorBoundary: FallbackProps['resetErrorBoundary'];
+};
+
+export const ErrorFallback: React.FC<Props> = ({
+  error, // MEMO: もしエラーの種類によって表示するメッセージを変えたい場合はコメントアウトを外す
+  resetErrorBoundary,
+}) => {
+  return (
+    <>
+      <div role="alert" className={styles.allert}>
+        <ErrorMessage
+          error={error} // MEMO: もしエラーの種類によって表示するメッセージを変えたい場合はコメントアウトを外す
+        />
+      </div>
+      <Button
+        customStyle={styles.button}
+        onClick={resetErrorBoundary}
+        color={'redFill'}
+      >
+        もう一度試す
+      </Button>
+    </>
+  );
+};

--- a/react/src/components/ErrorFallback/ErrorFallback.tsx
+++ b/react/src/components/ErrorFallback/ErrorFallback.tsx
@@ -21,14 +21,14 @@ type Props = {
 };
 
 export const ErrorFallback: React.FC<Props> = ({
-  error, // MEMO: もしエラーの種類によって表示するメッセージを変えたい場合はコメントアウトを外す
+  error,
   resetErrorBoundary,
 }) => {
   return (
     <>
       <div role="alert" className={styles.allert}>
         <ErrorMessage
-          error={error} // MEMO: もしエラーの種類によって表示するメッセージを変えたい場合はコメントアウトを外す
+          error={error}
         />
       </div>
       <Button

--- a/react/src/components/ErrorFallback/ErrorMessage.tsx
+++ b/react/src/components/ErrorFallback/ErrorMessage.tsx
@@ -1,0 +1,29 @@
+import { css } from 'styled-system/css';
+
+const styles = {
+  title: css({
+    color: '#fa5252',
+    fontSize: '1.25rem',
+    fontWeight: 'bold',
+    padding: '0.25em',
+  }),
+};
+
+const createDisplayErrorMessage = (error: Error) => {
+  console.log(error); // TODO エラーの種類によって表示するメッセージを変える
+
+  return '予期せぬエラーが発生しました。申し訳ありませんが、時間をおいて再度お試しください。';
+};
+
+type Props = {
+  error: Error;
+};
+
+export const ErrorMessage: React.FC<Props> = ({ error }) => {
+  return (
+    <>
+      <p className={styles.title}>エラーが発生しました。</p>
+      <p>{createDisplayErrorMessage(error)}</p>
+    </>
+  );
+};

--- a/react/src/components/ErrorFallback/index.ts
+++ b/react/src/components/ErrorFallback/index.ts
@@ -1,0 +1,1 @@
+export { ErrorFallback } from './ErrorFallback';

--- a/react/src/components/index.ts
+++ b/react/src/components/index.ts
@@ -1,2 +1,3 @@
+export { ErrorFallback } from './ErrorFallback';
 export { DefaultLayout } from './layout/DefaultLayout/DefaultLayout';
 export { Button } from './Button';

--- a/react/src/components/layout/DefaultLayout/DefaultLayout.tsx
+++ b/react/src/components/layout/DefaultLayout/DefaultLayout.tsx
@@ -1,7 +1,15 @@
+import { ErrorBoundary } from 'react-error-boundary';
 import { css } from 'styled-system/css';
+import { ErrorFallback } from '@/components';
 
 type Props = {
   children: React.ReactNode;
+};
+
+const onError = (error: Error, info: { componentStack: string }) => {
+  // ここでログ出力などを行う
+  console.log('error.message', error.message);
+  console.log('info.componentStack:', info.componentStack);
 };
 
 export const DefaultLayout: React.FC<Props> = ({ children }) => {
@@ -13,7 +21,9 @@ export const DefaultLayout: React.FC<Props> = ({ children }) => {
         padding: '0 1rem',
       })}
     >
-      {children}
+      <ErrorBoundary FallbackComponent={ErrorFallback} onError={onError}>
+        {children}
+      </ErrorBoundary>
     </main>
   );
 };

--- a/react/src/features/room/components/RoomControll/RoomControll.tsx
+++ b/react/src/features/room/components/RoomControll/RoomControll.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useErrorBoundary } from 'react-error-boundary';
 import { fetchGameStart, finishRoom } from '../../api';
 import { RoomControllButton } from './RoomControllButton';
 import { ExhaustiveError } from '@/error';
@@ -9,6 +10,7 @@ type Props = {
 
 export const RoomControll: React.FC<Props> = ({ hostFlg }) => {
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const { showBoundary } = useErrorBoundary();
 
   const handleGameStart = async () => {
     try {
@@ -24,7 +26,7 @@ export const RoomControll: React.FC<Props> = ({ hostFlg }) => {
           throw new ExhaustiveError(gameStartStatus);
       }
     } catch (error) {
-      console.log(error); // TODO: ErrorFallback を実装する
+      showBoundary(error);
     }
   };
 
@@ -40,9 +42,8 @@ export const RoomControll: React.FC<Props> = ({ hostFlg }) => {
   const handleGameExit = async () => {
     try {
       await finishRoom();
-      // TODO: 解散処理を実装する（ Web Socket で解散のメッセージを受信する）
     } catch (error) {
-      console.log(error); // TODO: ErrorFallback を実装する
+      showBoundary(error);
     }
   };
 

--- a/react/src/features/room/hooks/useRoomData.ts
+++ b/react/src/features/room/hooks/useRoomData.ts
@@ -17,6 +17,7 @@ export const useRoomData = (): RoomIndexResponseBody => {
         const response = await fetchRoomIndex();
         setRoomIndexResponseBody(response);
       } catch (error) {
+        // ↓ FIXME: ErrorBoundaryの外にあるので、showBoundary が使えない問題がある。
         console.log(error); // TODO: ErrorFallbackを実装する
       }
     };

--- a/react/src/features/top/components/JoinRoom/JoinRoom.tsx
+++ b/react/src/features/top/components/JoinRoom/JoinRoom.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEventHandler } from 'react';
+import { useErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import { joinRoom } from '../../api';
 import { JoinRoomButton } from './JoinRoomButton';
@@ -10,6 +11,7 @@ type Props = {
 
 export const JoinRoom: React.FC<Props> = ({ className }) => {
   const navigate = useNavigate();
+  const { showBoundary } = useErrorBoundary();
 
   const [roomId, setRoomId] = useState('');
   const [joinRoomResult, setJoinRoomResult] = useState('');
@@ -44,7 +46,7 @@ export const JoinRoom: React.FC<Props> = ({ className }) => {
           throw new ExhaustiveError(status);
       }
     } catch (error) {
-      console.log(error); // TODO: ErrorFallbackを実装する
+      showBoundary(error);
     }
   };
 

--- a/react/src/features/top/components/MakeRoomButton/MakeRoomButton.tsx
+++ b/react/src/features/top/components/MakeRoomButton/MakeRoomButton.tsx
@@ -1,3 +1,4 @@
+import { useErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import { createRoom } from '../../api';
 import makeBtn from './make_room.png';
@@ -8,6 +9,7 @@ type Props = {
 
 export const MakeRoomButton: React.FC<Props> = ({ className }) => {
   const navigate = useNavigate();
+  const { showBoundary } = useErrorBoundary();
 
   const handleClick = async () => {
     try {
@@ -15,7 +17,7 @@ export const MakeRoomButton: React.FC<Props> = ({ className }) => {
 
       navigate('/room');
     } catch (error) {
-      console.log(error); // TODO: ErrorFallbackを実装する
+      showBoundary(error);
     }
   };
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -372,7 +372,7 @@
     "@babel/plugin-syntax-jsx" "^7.22.5"
     "@babel/types" "^7.22.5"
 
-"@babel/runtime@^7.20.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.20.7":
   "integrity" "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ=="
   "resolved" "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz"
   "version" "7.22.6"
@@ -5879,6 +5879,13 @@
     "loose-envify" "^1.1.0"
     "scheduler" "^0.23.0"
 
+"react-error-boundary@^4.0.11":
+  "integrity" "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw=="
+  "resolved" "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz"
+  "version" "4.0.11"
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "react-is@^16.13.1":
   "integrity" "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
   "resolved" "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -5913,7 +5920,7 @@
   dependencies:
     "@remix-run/router" "1.7.1"
 
-"react@^16.8 || ^17 || ^18", "react@^16.8.0 || ^17 || ^18", "react@^17.0.2 || ^18.0.0", "react@^18.2.0", "react@>=16.8", "react@>=18.0.0", "react@0.14 || 15 || 16 || 17 || 18", "react@18.2.0":
+"react@^16.8 || ^17 || ^18", "react@^16.8.0 || ^17 || ^18", "react@^17.0.2 || ^18.0.0", "react@^18.2.0", "react@>=16.13.1", "react@>=16.8", "react@>=18.0.0", "react@0.14 || 15 || 16 || 17 || 18", "react@18.2.0":
   "integrity" "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="
   "resolved" "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   "version" "18.2.0"


### PR DESCRIPTION
# 対応したこと
- react-error-boundary の導入
- ErrorFallback コンポーネントの実装
- DefaultLayout に ErrorBoundary を適用

# 対応しなかったこと
- Custom Hook 内でのエラーについては本プロジェクトのディレクトリ構造上 ErrorBoundary  の外で発生するので、一旦保留した

# スクショ
再現：spring 未起動の状態で「へやをつくる」ボタンを押下（起動していないバックエンドにリクエストを投げて例外を発生させる）
## PC
![Sep-19-2023 15-31-52](https://github.com/nocox/one-night-jinroh/assets/9443634/05a9d650-0c64-488f-9412-6eb24b7cf40a)
## SP
![Sep-19-2023 15-32-01](https://github.com/nocox/one-night-jinroh/assets/9443634/acc9d678-fe9f-4207-ad76-0addd397e340)
