### PR TITLE
React版投票ページの投票ボタンを押下しても状態が変化しなかった問題を修正

### DIFF
--- a/react/src/features/game/vote/VotePage.tsx
+++ b/react/src/features/game/vote/VotePage.tsx
@@ -5,8 +5,14 @@ import { useGameRule, useWebSocket } from '@/hooks';
 import type { Subscribe } from '@/type';
 
 export const VotePage: React.FC = () => {
-  const { gameId, players, nightActLog, canVotePlayers, votingDestination } =
-    useVoteData();
+  const {
+    gameId,
+    players,
+    nightActLog,
+    canVotePlayers,
+    votingDestination,
+    setVotingDestination,
+  } = useVoteData();
 
   const { gameRuleList } = useGameRule(gameId);
 
@@ -30,6 +36,7 @@ export const VotePage: React.FC = () => {
       gameRuleList={gameRuleList}
       canVotePlayers={canVotePlayers}
       votingDestination={votingDestination}
+      setVottingDestination={setVotingDestination}
     />
   );
 };

--- a/react/src/features/game/vote/VoteTemplate.tsx
+++ b/react/src/features/game/vote/VoteTemplate.tsx
@@ -45,6 +45,9 @@ type Props = {
   gameRuleList: GameRule[];
   canVotePlayers: OtherPlayer[];
   votingDestination: number | undefined;
+  setVottingDestination: React.Dispatch<
+    React.SetStateAction<number | undefined>
+  >;
 };
 
 export const VoteTemplate: React.FC<Props> = ({
@@ -53,6 +56,7 @@ export const VoteTemplate: React.FC<Props> = ({
   gameRuleList,
   canVotePlayers,
   votingDestination,
+  setVottingDestination,
 }) => {
   return (
     <DefaultLayout>
@@ -78,6 +82,7 @@ export const VoteTemplate: React.FC<Props> = ({
           <VoteForm
             canVotePlayers={canVotePlayers}
             votingDestination={votingDestination}
+            setVotingDestination={setVottingDestination}
           />
         </div>
       </div>

--- a/react/src/features/game/vote/components/VoteForm/VoteForm.tsx
+++ b/react/src/features/game/vote/components/VoteForm/VoteForm.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
 import { css } from 'styled-system/css';
 import { Button, ContentBox } from '@/components';
 import type { OtherPlayer } from '@/features/game/type';
-import { postVoteForm } from '@/features/game/vote/api';
+import { useVoteForm } from '@/features/game/vote/hooks/useVoteForm';
 
 const styles = {
   title: css({
@@ -35,31 +34,21 @@ const styles = {
 type Props = {
   canVotePlayers: OtherPlayer[];
   votingDestination: number | undefined;
+  setVotingDestination: React.Dispatch<
+    React.SetStateAction<number | undefined>
+  >;
 };
 export const VoteForm: React.FC<Props> = ({
   canVotePlayers,
   votingDestination,
+  setVotingDestination,
 }) => {
-  const [selectedPlayerId, setSelectedPlayerId] = useState<number | undefined>(
-    votingDestination,
-  );
-  const [errorMessage, setErrorMessage] = useState<string>('');
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedPlayerId(Number(e.target.value));
-  };
-
-  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    if (selectedPlayerId === undefined) {
-      setErrorMessage('相手を選択してください。');
-
-      return;
-    }
-
-    await postVoteForm({ gameParticipantId: selectedPlayerId });
-    // FIXME バックエンドからのレスポンスを受け取りたい(今は何も返していない)
-  };
+  const {
+    selectedPlayerId,
+    handleSelectedPlayerIdChange,
+    handleVoteSubmit,
+    errorMessage,
+  } = useVoteForm(votingDestination, setVotingDestination);
 
   return (
     <ContentBox>
@@ -74,7 +63,7 @@ export const VoteForm: React.FC<Props> = ({
                   name="votingDestination"
                   value={player.id}
                   checked={selectedPlayerId === player.id}
-                  onChange={handleChange}
+                  onChange={handleSelectedPlayerIdChange}
                   disabled={votingDestination !== undefined}
                 />
                 {player.name}
@@ -85,7 +74,7 @@ export const VoteForm: React.FC<Props> = ({
         <div className={styles.voteButtonWrapper}>
           <Button
             type="submit"
-            onClick={handleSubmit}
+            onClick={handleVoteSubmit}
             disabled={votingDestination !== undefined}
             isDisabled={votingDestination !== undefined}
           >

--- a/react/src/features/game/vote/hooks/useVoteData.ts
+++ b/react/src/features/game/vote/hooks/useVoteData.ts
@@ -9,6 +9,9 @@ export const useVoteData = (): {
   players: Player[] | undefined;
   canVotePlayers: OtherPlayer[] | undefined;
   votingDestination: number | undefined;
+  setVotingDestination: React.Dispatch<
+    React.SetStateAction<number | undefined>
+  >;
 } => {
   const [gameId, setGameId] = useState<number | undefined>();
   const [nightActLog, setNightActLog] = useState<string | undefined>();
@@ -49,5 +52,12 @@ export const useVoteData = (): {
     void fetchVoteIndexAsync();
   }, []);
 
-  return { gameId, nightActLog, players, canVotePlayers, votingDestination };
+  return {
+    gameId,
+    nightActLog,
+    players,
+    canVotePlayers,
+    votingDestination,
+    setVotingDestination,
+  };
 };

--- a/react/src/features/game/vote/hooks/useVoteForm.ts
+++ b/react/src/features/game/vote/hooks/useVoteForm.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { postVoteForm } from '@/features/game/vote//api';
+
+export const useVoteForm = (
+  votingDestination: number | undefined,
+  setVotingDestination: React.Dispatch<
+    React.SetStateAction<number | undefined>
+  >,
+): {
+  selectedPlayerId: number | undefined;
+  errorMessage: string;
+  handleSelectedPlayerIdChange: (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  handleVoteSubmit: (
+    e: React.MouseEvent<HTMLButtonElement>,
+  ) => Promise<void> | void;
+} => {
+  const [selectedPlayerId, setSelectedPlayerId] = useState<number | undefined>(
+    votingDestination,
+  );
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const handleSelectedPlayerIdChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setSelectedPlayerId(Number(e.target.value));
+  };
+
+  const handleVoteSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (selectedPlayerId === undefined) {
+      setErrorMessage('相手を選択してください。');
+
+      return;
+    }
+
+    await postVoteForm({ gameParticipantId: selectedPlayerId });
+    setVotingDestination(selectedPlayerId);
+  };
+
+  return {
+    selectedPlayerId,
+    errorMessage,
+    handleSelectedPlayerIdChange,
+    handleVoteSubmit,
+  };
+};


### PR DESCRIPTION
# 対応したこと
- useVoteFormフックを実装し、VoteFormのロジックを切りだした
- votingDestination をボタンUIの状態変化に使用しているので、投票を行った際にvotingDestinationを変更できるように修正した
