### PR TITLE
Draft: ページ離脱防止用のconfirmウィンドウを表示するためのカスタムフックを実装

### DIFF
--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useWebSocket } from './useWebSocket';
 export { useGameRule } from './useGameRule';
+export { useBeforeUnload } from './useBeforeUnload';

--- a/react/src/hooks/useBeforeUnload.ts
+++ b/react/src/hooks/useBeforeUnload.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react"
+
+
+export const useBeforeUnload = (): void => {
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = 'ゲームを終了しても良いですか？';
+
+      return 'ゲームを終了しても良いですか？';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
+}


### PR DESCRIPTION
# 対応すること/しないこと
- ページ離脱防止用に、`beforeunload`イベントのリスナーをカスタムフックで実装する
- 実装したカスタムフックの呼び出しは実装しない

# スクショ
![Oct-25-2023 18-27-49](https://github.com/nocox/one-night-jinroh/assets/9443634/40c223c1-973c-47f0-af11-5d75100439ec)

# 補足
この機能を再現するかどうか悩ましいため、相談したい
→https://www.notion.so/nocox/React-a27b4627204e4c619b28a36ee75357c9?pvs=4
- SPAの遷移ガードは使えなさそう
- beforeunloadイベントはかなり使いづらい
  - ブラウザ依存の要素が強く、実装者の介入が難しい
  - UXを損なう可能性が高い
