### PR TITLE
COアイコンをテキスト選択不可・ドラッグ不可・コンテキストメニューOpen不可にした

### DIFF
--- a/react/src/features/game/talk/components/ComingOut/ComingOut.tsx
+++ b/react/src/features/game/talk/components/ComingOut/ComingOut.tsx
@@ -43,6 +43,9 @@ const styles = {
       border: '5px solid lightgreen',
     },
   }),
+  iconImage: css({
+    userSelect: 'none',
+  }),
 };
 
 type Props = {
@@ -81,7 +84,17 @@ export const ComingOut: React.FC<Props> = ({ getMyPlayer }) => {
                   await handleClick(character);
                 }}
               >
-                <img src={character.iconPath} alt={character.japaneseName} />
+                <img
+                  src={character.iconPath}
+                  alt={character.japaneseName}
+                  className={styles.iconImage}
+                  onDragStart={(e) => {
+                    e.preventDefault();
+                  }}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                  }}
+                />
               </button>
             </li>
           );


### PR DESCRIPTION
# スクショなど
わかりづらいけど

## before
![Apr-13-2024 14-52-00](https://github.com/nocox/one-night-jinroh/assets/9443634/96ed17ea-ba55-4b27-a71a-0d203a8d376b)

## after
![Apr-13-2024 14-52-42](https://github.com/nocox/one-night-jinroh/assets/9443634/1ec26cdb-1171-48e5-85ed-849b5766b8a1)
