### PR TITLE
ゲームルールの変更

### DIFF
--- a/spring/src/main/java/com/okaka/onenightjinroh/application/domain/Rule.kt
+++ b/spring/src/main/java/com/okaka/onenightjinroh/application/domain/Rule.kt
@@ -12,9 +12,9 @@ class Rule(
                 4 to listOf(1L,2L,3L,4L,5L,6L),
                 5 to listOf(1L,2L,3L,4L,5L,6L,1L),
                 6 to listOf(1L,2L,3L,4L,5L,6L,1L,2L),
-                7 to listOf(1L,2L,3L,4L,5L,6L,1L,2L,3L),
-                8 to listOf(1L,2L,3L,4L,5L,6L,1L,2L,3L,4L),
-                9 to listOf(1L,2L,3L,4L,5L,6L,1L,2L,3L,4L,5L),
+                7 to listOf(1L,2L,3L,4L,5L,6L,1L,1L,2L),
+                8 to listOf(1L,2L,3L,4L,5L,6L,1L,1L,2L,4L),
+                9 to listOf(1L,2L,3L,4L,5L,6L,1L,1L,2L,4L,5L),
             )
 
         fun createByParticipantCount(playerNum: Int): Rule {


### PR DESCRIPTION
# 対応したこと
占い師が2人以上存在するルールから、占い師を1人削除し、村人を1人追加した。